### PR TITLE
to_hash accepts an options argument

### DIFF
--- a/lib/chozo/hashie_ext/hash.rb
+++ b/lib/chozo/hashie_ext/hash.rb
@@ -2,8 +2,8 @@ module Hashie
   # @author Jamie Winsor <jamie@vialstudios.com>
   class Hash < ::Hash
     # Ensure we always symbolize keys when calling #to_hash
-    def to_hash
-      super.deep_symbolize_keys
+    def to_hash(options = {})
+      super(options).deep_symbolize_keys
     end
   end
 end


### PR DESCRIPTION
to_hash takes an options argument. When you added this 7 months ago to_hash didn't accept any arguments. They reverted this change since it broken a number of Gems. See pull request below.

See https://github.com/intridea/hashie/pull/85
